### PR TITLE
feat(**/cpm/rocthrust*): Option for prefering/forcing use of local version

### DIFF
--- a/rapids-cmake/cpm/hipcomp.cmake
+++ b/rapids-cmake/cpm/hipcomp.cmake
@@ -161,8 +161,12 @@ function(rapids_cpm_hipcomp)
   endif()
 
   if (HIP_AS_CUDA)
-    add_library(nvcomp::nvcomp ALIAS ${hipcomp_orig})
-    add_library(nvcomp ALIAS ${hipcomp_orig})
+    if (NOT DEFINED nvcomp::nvcomp)
+      add_library(nvcomp::nvcomp ALIAS ${hipcomp_orig})
+    endif()
+    if (NOT DEFINED nvcomp)
+      add_library(nvcomp ALIAS ${hipcomp_orig})
+    endif()
   endif()
 
   # Propagate up variables that CPMFindPackage provide

--- a/rapids-cmake/cpm/libhipcxx.cmake
+++ b/rapids-cmake/cpm/libhipcxx.cmake
@@ -127,6 +127,7 @@ function(rapids_cpm_libhipcxx)
     # the headers to `include/rapids/libhipcxx`
     include(GNUInstallDirs)
     set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/rapids/libhipcxx")
+    set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/rapids/")
 
     # libhipcxx 1.8 has a bug where it doesn't generate proper exclude rules for the
     # `[cub|libhipcxx]-header-search` files, which causes the build tree version to be installed

--- a/rapids-cmake/cpm/rmm-rocm.cmake
+++ b/rapids-cmake/cpm/rmm-rocm.cmake
@@ -97,7 +97,7 @@ function(rapids_cpm_rmm_rocm)
   rapids_cpm_generate_patch_command(rmm-rocm ${version} patch_command)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(rmm-rocm ${version} ${ARGN} {_RAPIDS_UNPARSED_ARGUMENTS}
+  rapids_cpm_find(rmm ${version} ${ARGN} {_RAPIDS_UNPARSED_ARGUMENTS}
                   GLOBAL_TARGETS rmm::rmm
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}

--- a/rapids-cmake/cpm/rocthrust.cmake
+++ b/rapids-cmake/cpm/rocthrust.cmake
@@ -72,6 +72,11 @@ Option `PREFER_LOCAL <value>` has no effect if `USE_LOCAL ON` is specified.
 TRUE/FALSE, YES/NO, Y/N, ...; more details:
 https://cmake.org/cmake/help/latest/command/if.html#constant)
 
+There is also the option to override the behavior via the environment variables:
+
+`RAPIDS_CMAKE_ROCTHRUST_PREFER_LOCAL`
+`RAPIDS_CMAKE_ROCTHRUST_USE_LOCAL`
+
 Result Targets
 ^^^^^^^^^^^^^^
   roc::rocthrust target will be created
@@ -109,12 +114,20 @@ function(rapids_cpm_rocthrust)
   set(tmp_CPM_USE_LOCAL_PACKAGES CPM_USE_LOCAL_PACKAGES) # memorize original value
   set(tmp_CPM_LOCAL_PACKAGES_ONLY CPM_LOCAL_PACKAGES_ONLY) # memorize original value
 
+    # note: order doesn't matter
     if (_RAPIDS_PREFER_LOCAL)
       set(CPM_USE_LOCAL_PACKAGES ON)
+    elseif($ENV{RAPIDS_CMAKE_ROCTHRUST_PREFER_LOCAL}) # note: can't OR with if condition as $ENV{..} may eval to ""
+      set(CPM_USE_LOCAL_PACKAGES ON)
     endif()
+
+    # note: order doesn't matter
     if (_RAPIDS_USE_LOCAL)
       set(CPM_LOCAL_PACKAGES_ONLY ON)
+    elseif($ENV{RAPIDS_CMAKE_ROCTHRUST_USE_LOCAL}) # note: can't OR with if condition as $ENV{..} may eval to ""
+      set(CPM_LOCAL_PACKAGES_ONLY ON)
     endif()
+
     rapids_cpm_find(rocthrust ${version} ${ARGN} ${_RAPIDS_UNPARSED_ARGUMENTS}
                     GLOBAL_TARGETS rocthrust roc::rocthrust
                     CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT

--- a/rapids-cmake/cpm/rocthrust.cmake
+++ b/rapids-cmake/cpm/rocthrust.cmake
@@ -116,7 +116,7 @@ function(rapids_cpm_rocthrust)
       set(CPM_LOCAL_PACKAGES_ONLY ON)
     endif()
     rapids_cpm_find(rocthrust ${version} ${ARGN} ${_RAPIDS_UNPARSED_ARGUMENTS}
-                    GLOBAL_TARGETS rocthrust
+                    GLOBAL_TARGETS rocthrust roc::rocthrust
                     CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT
                     GIT_REPOSITORY ${repository}
                     GIT_TAG ${tag}
@@ -128,20 +128,18 @@ function(rapids_cpm_rocthrust)
   set(CPM_USE_LOCAL_PACKAGES tmp_CPM_USE_LOCAL_PACKAGES) # restore original value
   set(CPM_LOCAL_PACKAGES_ONLY tmp_CPM_LOCAL_PACKAGES_ONLY) # restore original value
 
-  if(NOT TARGET rocthrust)
-    message(FATAL_ERROR "Expected rocthrust to exist")
-  endif()
-
-  if (NOT TARGET roc::rocthrust)
+  if (NOT TARGET roc::rocthrust AND TARGET rocthrust)
+    # target is named 'rocthrust' if this NOT a local installation
     add_library(roc::rocthrust ALIAS rocthrust)
+    if(_RAPIDS_BUILD_EXPORT_SET)
+      install(TARGETS rocthrust EXPORT ${_RAPIDS_BUILD_EXPORT_SET})
+    endif()
+  elseif(NOT TARGET roc::rocthrust)
+    message(FATAL_ERROR "Expected rocthrust or roc::rocthrust to exist")
   endif()
 
   if (NOT DEFINED rocthrust_BINARY_DIR)
     message(rocthrust_BINARY_DIR "Expected variable rocthrust_BINARY_DIR to be defined")
-  endif()
-
-  if(_RAPIDS_BUILD_EXPORT_SET)
-    install(TARGETS rocthrust EXPORT ${_RAPIDS_BUILD_EXPORT_SET})
   endif()
 
   include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")

--- a/rapids-cmake/cpm/rocthrust.cmake
+++ b/rapids-cmake/cpm/rocthrust.cmake
@@ -130,13 +130,14 @@ function(rapids_cpm_rocthrust)
 
     rapids_cpm_find(rocthrust ${version} ${ARGN} ${_RAPIDS_UNPARSED_ARGUMENTS}
                     GLOBAL_TARGETS rocthrust roc::rocthrust
-                    CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT
-                    GIT_REPOSITORY ${repository}
-                    GIT_TAG ${tag}
-                    GIT_SHALLOW ${shallow}
-                    PATCH_COMMAND ${patch_command}
-                    EXCLUDE_FROM_ALL ${exclude}
-                    OPTIONS "DOWNLOAD_ROCPRIM ON")
+                    CPM_ARGS
+                      # FIND_PACKAGE_ARGUMENTS EXACT # we also accept more recent versions
+                      GIT_REPOSITORY ${repository}
+                      GIT_TAG ${tag}
+                      GIT_SHALLOW ${shallow}
+                      PATCH_COMMAND ${patch_command}
+                      EXCLUDE_FROM_ALL ${exclude}
+                      OPTIONS "DOWNLOAD_ROCPRIM ON")
 
   set(CPM_USE_LOCAL_PACKAGES tmp_CPM_USE_LOCAL_PACKAGES) # restore original value
   set(CPM_LOCAL_PACKAGES_ONLY tmp_CPM_LOCAL_PACKAGES_ONLY) # restore original value

--- a/rapids-cmake/cpm/rocthrust.cmake
+++ b/rapids-cmake/cpm/rocthrust.cmake
@@ -48,10 +48,29 @@ tracking of these dependencies for correct export support.
 
   rapids_cpm_rocthrust([BUILD_EXPORT_SET <export-name>]
                      [INSTALL_EXPORT_SET <export-name>]
+                     [PREFER_LOCAL <prefer-local>]
+                     [USE_LOCAL <use-local>]
                      [<CPM_ARGS> ...])
 
 .. |PKG_NAME| replace:: rocthrust
 .. include:: common_package_args.txt
+
+Prefer/Use Local rocThrust Installation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you specify the key-value pair `PREFER_LOCAL ON`, this function first look for a local
+version of `rocThrust`, e.g., one from a ROCm installation.
+The default behavior is that of `PREFER_LOCAL OFF`, i.e., that rocThrust is downloaded
+from its Git repository.
+
+If you specify the key-value pair `USE_LOCAL ON` instead, this function will ONLY look
+for a local version  of `rocThrust`. An error will be reported if no local version could be found.
+The default behavior is that of `USE_LOCAL OFF`.
+Option `PREFER_LOCAL <value>` has no effect if `USE_LOCAL ON` is specified.
+
+(Note that instead of the values "ON" and "OFF", alternative values can be specified such as
+TRUE/FALSE, YES/NO, Y/N, ...; more details:
+https://cmake.org/cmake/help/latest/command/if.html#constant)
 
 Result Targets
 ^^^^^^^^^^^^^^
@@ -71,12 +90,11 @@ Result Variables
 
 #]=======================================================================]
 # cmake-lint: disable=R0915
-# TODO(HIP/AMD): Namespace support is not really sorted out yet.
 function(rapids_cpm_rocthrust)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.rocthrust")
 
   set(options)
-  set(one_value BUILD_EXPORT_SET INSTALL_EXPORT_SET)
+  set(one_value BUILD_EXPORT_SET INSTALL_EXPORT_SET USE_LOCAL PREFER_LOCAL)
   set(multi_value)
   cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
@@ -87,15 +105,28 @@ function(rapids_cpm_rocthrust)
   rapids_cpm_generate_patch_command(rocthrust ${version} patch_command)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(rocthrust ${version} ${ARGN} ${_RAPIDS_UNPARSED_ARGUMENTS}
-                  GLOBAL_TARGETS rocthrust
-                  CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT
-                  GIT_REPOSITORY ${repository}
-                  GIT_TAG ${tag}
-                  GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND ${patch_command}
-                  EXCLUDE_FROM_ALL ${exclude}
-                  OPTIONS "DOWNLOAD_ROCPRIM ON")
+
+  set(tmp_CPM_USE_LOCAL_PACKAGES CPM_USE_LOCAL_PACKAGES) # memorize original value
+  set(tmp_CPM_LOCAL_PACKAGES_ONLY CPM_LOCAL_PACKAGES_ONLY) # memorize original value
+
+    if (_RAPIDS_PREFER_LOCAL)
+      set(CPM_USE_LOCAL_PACKAGES ON)
+    endif()
+    if (_RAPIDS_USE_LOCAL)
+      set(CPM_LOCAL_PACKAGES_ONLY ON)
+    endif()
+    rapids_cpm_find(rocthrust ${version} ${ARGN} ${_RAPIDS_UNPARSED_ARGUMENTS}
+                    GLOBAL_TARGETS rocthrust
+                    CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT
+                    GIT_REPOSITORY ${repository}
+                    GIT_TAG ${tag}
+                    GIT_SHALLOW ${shallow}
+                    PATCH_COMMAND ${patch_command}
+                    EXCLUDE_FROM_ALL ${exclude}
+                    OPTIONS "DOWNLOAD_ROCPRIM ON")
+
+  set(CPM_USE_LOCAL_PACKAGES tmp_CPM_USE_LOCAL_PACKAGES) # restore original value
+  set(CPM_LOCAL_PACKAGES_ONLY tmp_CPM_LOCAL_PACKAGES_ONLY) # restore original value
 
   if(NOT TARGET rocthrust)
     message(FATAL_ERROR "Expected rocthrust to exist")


### PR DESCRIPTION
## Main change

This PR makes the following changes:

* Look for a minimal version for rocThrust no longer for an exact version 
* Always look for a local installation, do not download rocThrust any longer

Motivation: rocThrust always comes bundled with ROCm releases.

## Fixes

hipcomp: Create `nvcomp::nvcomp` alias target only if it doesn't exist yet.

## Previously intended implementation which is mostly commented out now

Add options `USE_LOCAL <ON|OFF> [OFF]` and `PREFER_LOCAL <ON|OFF> [OFF]` to force the use of a local installation (error if not found) and prefer the use of a local installation of rocThrust (download from git repo if not found), respectively.

Further add option to override the find locally/download behavior via the environment variables:

* `RAPIDS_CMAKE_ROCTHRUST_PREFER_LOCAL` <ON|OFF|..> [OFF]
* `RAPIDS_CMAKE_ROCTHRUST_USE_LOCAL`    <ON|OFF|..> [OFF]

This allows to easily change the behavior from within a build script/Jenkins pipeline script.

# Checks

* [x] works when new options are unspecified
* [x] works when only one options is specified
* [x] works when both options are specified