### PR TITLE
hotfix(rocthrust.cmake):  don't make rocthrust targets global

### DIFF
--- a/rapids-cmake/cpm/rocthrust.cmake
+++ b/rapids-cmake/cpm/rocthrust.cmake
@@ -149,7 +149,6 @@ function(rapids_cpm_rocthrust)
   # endif()
 
   rapids_cpm_find(rocthrust ${version} ${_RAPIDS_UNPARSED_ARGUMENTS}
-                  GLOBAL_TARGETS roc::rocthrust roc::rocprim_hip roc::hipstdpar
                   CPM_ARGS
                     # FIND_PACKAGE_ARGUMENTS EXACT # we also accept more recent versions
                     GIT_REPOSITORY ${repository}


### PR DESCRIPTION
Typical error message:

Attempt to promote imported target "<target-name>" to global scope (by setting IMPORTED_GLOBAL) which is not built in this directory.