### PR TITLE
hotfix(RAPIDS.cmake): always append "/" to RAPIDS_CMAKE_URL

### DIFF
--- a/RAPIDS.cmake
+++ b/RAPIDS.cmake
@@ -80,7 +80,7 @@ endif()
 # Allow users to control the exact URL passed to FetchContent
 if(NOT rapids-cmake-url)
   if(DEFINED ENV{RAPIDS_CMAKE_URL})
-    set(rapids-cmake-url $ENV{RAPIDS_CMAKE_URL})
+    set(rapids-cmake-url "$ENV{RAPIDS_CMAKE_URL}/")
   else()
     # Construct a default URL if the user doesn't set one
     set(rapids-cmake-url "https://github.com/${rapids-cmake-repo}/")


### PR DESCRIPTION
User-defined rapids-cmake-url will later on be concatenated with a suffix. This concatenation expects that the `rapids-cmake-url` ends with "/".  Note that having `rapids-cmake-url` end with "//" instead of "/" is no issue.

# TODOs: Check if this works via CI job

* [x] Url without "/" suffix.
* [x] Url with "/" suffix.

# Post-merge TODOs

* [x] Synchronize internal repository.